### PR TITLE
Giving possibility to change base refresh interval

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -129,6 +129,7 @@ var sender = function(opt, parent) {
   this.ip = options.ip || '255.255.255.255';
   this.port = options.port || 6454;
   this.verbose = this.parent.verbose;
+  this.base_refresh_interval = options.base_refresh_interval || 1000;
 
   // Validate Input
   if (this.net > 127) {
@@ -177,10 +178,10 @@ var sender = function(opt, parent) {
   this.transmit();
 
 
-  // Send Frame all 1000ms even there is no channel change
+  // Send Frame in regular intervals (as given in base_refresh_interval) - even there was no channel changed
   this.interval = setInterval(() => {
     this.transmit();
-  }, 1000);
+  }, this.base_refresh_interval);
 };
 // Transmit function
 sender.prototype.transmit = function() {

--- a/lib.js
+++ b/lib.js
@@ -178,7 +178,7 @@ var sender = function(opt, parent) {
   this.transmit();
 
 
-  // Send Frame in regular intervals (as given in base_refresh_interval) - even there was no channel changed
+  // Send Frame every base_refresh_interval ms - even if no channel was changed
   this.interval = setInterval(() => {
     this.transmit();
   }, this.base_refresh_interval);


### PR DESCRIPTION
As default 1000ms interval is quite long for some use cases, but ressources saving for some others,
I've added a new option called "base_refresh_interval", which then defaults to 1000.

When accepting this fork, an update of Readme file would be neccessary, with change of sentence: "
Please Note: dmxnet transmits a dmx-frame every 1000ms even if no channel has changed its value!"