### PR TITLE
support receiving ArtDMX packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Only the sender could be considered working by now.
 
 
 ## Changelog
+**v0.4.0**
+Added support for receiving ArtDMX packets. 
+
 **v0.3.0**
 Added support for base_refresh_interval, add sender.reset()
 
@@ -166,7 +169,6 @@ Resets all channels of this sender object to zero.
 
 ## ToDo:
 
-- Receiving ArtDmx
 - Act as Controller (Sending ArtPoll, Receiving ArtPollReply)
 - Maybe support sACN?
 

--- a/example_rx.js
+++ b/example_rx.js
@@ -7,3 +7,8 @@ var dmxnet = new dmxlib.dmxnet({verbose: 2});
 setInterval(function() {
   console.log(dmxnet.controllers);
 }, 30000);
+
+dmxnet.on('ArtDMX', function({ universe, data }) {
+  console.log('DMX universe:', universe);
+  console.log('DMX data:', data);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,10 +291,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dmxnet",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dmxnet",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "ArtNet-DMX-sender and receiver for nodejs",
   "main": "lib.js",
   "scripts": {


### PR DESCRIPTION
This uses `EventEmitter` to emit an `ArtDMX` event when an inbound ArtDMX packet arrives. See the modified `example_rx.js` file: 

```diff
+ dmxnet.on('ArtDMX', function({ universe, data }) {
+   console.log('DMX universe:', universe);
+   console.log('DMX data:', data);
+ });
```

`data` is an object with each DMX channel and it's value, e.g. 
```json
{
  "1": 255,
  "2": 127,
  "4": 255
}
```