### PR TITLE
Logging: Add Logger-Options to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Options:
   verbose: 1, //Verbosity, default 0
   oem: 0, //OEM Code from artisticlicense, default to dmxnet OEM.
   sName: "Text", // 17 char long node description, default to "dmxnet"
-  lName: "Long description" // 63 char long node description, default to "dmxnet - OpenSource ArtNet Transceiver"
+  lName: "Long description", // 63 char long node description, default to "dmxnet - OpenSource ArtNet Transceiver"
+  log: {name: 'dmxnet', files: false} // Logging Options, see https://www.npmjs.com/package/@hibas123/nodelogging#setup
 }
 ```
 

--- a/example_tx.js
+++ b/example_tx.js
@@ -4,6 +4,10 @@ var dmxlib = require('./lib.js');
 // Create new dmxnet instance
 var dmxnet = new dmxlib.dmxnet({
   verbose: 1,
+  log: {
+    files: false,
+    name: "dmxnet"
+  }
 });
 // Create new Sender instance
 var sender = dmxnet.newSender({

--- a/lib.js
+++ b/lib.js
@@ -8,9 +8,7 @@ const Netmask = require('netmask').Netmask;
 // Require Logging
 const LoggingBase = require('@hibas123/nodelogging').LoggingBase;
 // Init Logger
-const log = new LoggingBase({
-  name: 'dmxnet',
-});
+let log;
 
 // ArtDMX Header for jspack
 var ArtDmxHeaderFormat = '!7sBHHBBBBH';
@@ -32,6 +30,7 @@ class dmxnet {
     this.sName = options.sName || 'dmxnet'; // Shortname
     this.lName = options.lName ||
       'dmxnet - OpenSource ArtNet Transceiver'; // Longname
+    this.logOptions = options.log || {name: 'dmxnet'};
     // Set log levels
     if (this.verbose > 0) {
       // ToDo: Set Log Level
@@ -41,6 +40,8 @@ class dmxnet {
     } else {
       // ToDo: Set Log Level
     }
+    // Create Logger
+    log = new LoggingBase(this.logOptions);
     // Log started information
     log.log('started with options ' + JSON.stringify(options));
 


### PR DESCRIPTION
Add's the logger-options from https://www.npmjs.com/package/@hibas123/nodelogging#setup to the constructor.
Enables/Disable logging to console/files or modify the log file path.
Should close #18.