### PR TITLE
Add hosts options to bind ipv4 addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Options:
   verbose: 1, //Verbosity, default 0
   oem: 0, //OEM Code from artisticlicense, default to dmxnet OEM.
   sName: "Text", // 17 char long node description, default to "dmxnet"
-  lName: "Long description" // 63 char long node description, default to "dmxnet - OpenSource ArtNet Transceiver"
+  lName: "Long description", // 63 char long node description, default to "dmxnet - OpenSource ArtNet Transceiver"
+  hosts: ["127.0.0.1"] // Interfaces to listen to, all by default
 }
 ```
 

--- a/lib.js
+++ b/lib.js
@@ -32,6 +32,7 @@ class dmxnet {
     this.sName = options.sName || 'dmxnet'; // Shortname
     this.lName = options.lName ||
       'dmxnet - OpenSource ArtNet Transceiver'; // Longname
+    this.hosts = options.hosts || []
     // Set log levels
     if (this.verbose > 0) {
       // ToDo: Set Log Level
@@ -53,12 +54,14 @@ class dmxnet {
       this.interfaces[key].forEach((val) => {
         if (val.family === 'IPv4') {
           var netmask = new Netmask(val.cidr);
-          this.ip4.push({
-            ip: val.address,
-            netmask: val.netmask,
-            mac: val.mac,
-            broadcast: netmask.broadcast,
-          });
+          if (this.hosts.length === 0 || (this.hosts.indexOf(val.address) !== -1)) {
+            this.ip4.push({
+              ip: val.address,
+              netmask: val.netmask,
+              mac: val.mac,
+              broadcast: netmask.broadcast,
+            });
+          }
         }
       });
     });
@@ -86,7 +89,7 @@ class dmxnet {
     // ToDo: IPv6
     // ToDo: Multicast
     // Catch Socket errors
-    this.listener4.on('error', function(err) {
+    this.listener4.on('error', function (err) {
       throw new Error('Socket error: ', err);
     });
     // Register listening object
@@ -494,7 +497,7 @@ class sender {
    */
   stop() {
     clearInterval(this.interval);
-    this.parent.senders = this.parent.senders.filter(function(value) {
+    this.parent.senders = this.parent.senders.filter(function (value) {
       if (value === this) {
         return false;
       }
@@ -593,7 +596,7 @@ class receiver extends EventEmitter {
 }
 
 // Parser & receiver
-var dataParser = function(msg, rinfo, parent) {
+var dataParser = function (msg, rinfo, parent) {
   log.debug(`got UDP from ${rinfo.address}:${rinfo.port}`);
   if (rinfo.size < 10) {
     log.debug('Payload to short');


### PR DESCRIPTION
Little change to allow binding ipv4 interfaces instead of all 
Take all interfaces if options isn't specified 

Exemple : 
` 
var dmx = new dmxlib.dmxnet({
            verbose: 1, 
            oem: 0, 
            sName: "Text", 
            lName: "Long description", 
            hosts : [
                "127.0.0.1",
                "172.16.2.116"
            ]
});
`