### PR TITLE
Logging: Replace @hibas123/nodelogging with winston logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 
 ```javascript
 {
-  verbose: 1, //Verbosity, default 0
+  log: { level: 'info' }, // Winston logger options
   oem: 0, //OEM Code from artisticlicense, default to dmxnet OEM.
   sName: "Text", // 17 char long node description, default to "dmxnet"
   lName: "Long description", // 63 char long node description, default to "dmxnet - OpenSource ArtNet Transceiver"

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,6 +1,7 @@
 import { Socket } from 'dgram'
 import { EventEmitter } from 'events'
 import { NetworkInterfaceInfo } from 'os'
+import { Logger, LoggerOptions } from 'winston'
 
 export interface NetworkInterface {
     ip: NetworkInterfaceInfo['address']
@@ -41,7 +42,6 @@ declare class sender {
     constructor(opt: SenderOptions | undefined, parent: dmxnet)
     parent: dmxnet
     socket_ready: boolean
-    verbose: DmxnetOptions['verbose']
     values: number[]
     ArtDmxSeq: number
     socket: Socket
@@ -103,7 +103,6 @@ declare class receiver extends EventEmitter {
      */
     constructor(opt: ReceiverOptions | undefined, parent: dmxnet)
     parent: dmxnet
-    verbose: DmxnetOptions['verbose']
     values: number[]
     subuninet: number
     /**
@@ -115,7 +114,7 @@ declare class receiver extends EventEmitter {
 }
 
 export interface DmxnetOptions {
-    verbose?: number
+    log?: LoggerOptions
     oem?: number
     listen?: number
     sName?: string
@@ -133,6 +132,7 @@ declare class dmxnet {
      * @param {DmxnetOptions} [options] - Options for the whole instance
      */
     constructor(options?: DmxnetOptions)
+    logger: Logger
     port: DmxnetOptions['listen']
     interfaces: Record<string, NetworkInterfaceInfo[]>
     ip4: NetworkInterface[]

--- a/lib.js
+++ b/lib.js
@@ -5,12 +5,7 @@ var EventEmitter = require('events');
 var jspack = require('jspack').jspack;
 const os = require('os');
 const Netmask = require('netmask').Netmask;
-// Require Logging
-const LoggingBase = require('@hibas123/nodelogging').LoggingBase;
-// Init Logger
-const log = new LoggingBase({
-  name: 'dmxnet',
-});
+const winston = require('winston');
 
 // ArtDMX Header for jspack
 var ArtDmxHeaderFormat = '!7sBHHBBBBH';
@@ -26,24 +21,33 @@ class dmxnet {
    */
   constructor(options) {
     // Parse all options and set defaults
-    this.verbose = options.verbose || 0;
     this.oem = options.oem || 0x2908; // OEM code hex
     this.port = options.listen || 6454; // Port listening for incoming data
     this.sName = options.sName || 'dmxnet'; // Shortname
     this.lName = options.lName ||
       'dmxnet - OpenSource ArtNet Transceiver'; // Longname
-    this.hosts = options.hosts || []
-    // Set log levels
-    if (this.verbose > 0) {
-      // ToDo: Set Log Level
-      if (this.verbose > 1) {
-        // ToDo: Set Log Level Debug
-      }
-    } else {
-      // ToDo: Set Log Level
-    }
+
+    // Init Logger
+    this.logOptions = Object.assign(
+      {
+        level: 'info',
+        format: winston.format.combine(
+          winston.format.splat(),
+          winston.format.timestamp(),
+          winston.format.label({ label: 'dmxnet' }),
+          winston.format.printf(({ level, message, label, timestamp }) => {
+            return `${timestamp} [${label}] ${level}: ${message}`;
+          })
+        ),
+        transports: [new winston.transports.Console()]
+      },
+      options.log
+    );
+    this.logger = new winston.createLogger(this.logOptions);
+
+    this.hosts = options.hosts || [];
     // Log started information
-    log.log('started with options ' + JSON.stringify(options));
+    this.logger.info('started with options: %o', options);
 
     // Get all network interfaces
     this.interfaces = os.networkInterfaces();
@@ -65,7 +69,7 @@ class dmxnet {
         }
       });
     });
-    log.debug('Interfaces: ' + JSON.stringify(this.ip4));
+    this.logger.verbose('Interfaces: %o', this.ip4);
     // init artPollReplyCount
     this.artPollReplyCount = 0;
     // Array containing reference to foreign controllers
@@ -98,7 +102,7 @@ class dmxnet {
     });
     // Start listening
     this.listener4.bind(this.port);
-    log.log('Listening on port ' + this.port);
+    this.logger.info('Listening on port ' + this.port);
     // Open Socket for sending broadcast data
     this.socket = dgram.createSocket('udp4');
     this.socket.bind(() => {
@@ -108,7 +112,7 @@ class dmxnet {
     // Periodically check Controllers
     setInterval(() => {
       if (this.controllers) {
-        log.debug('Check controller alive, count ' + this.controllers.length);
+        this.logger.verbose('Check controller alive, count ' + this.controllers.length);
         for (var index = 0; index < this.controllers.length; index++) {
           if ((new Date().getTime() -
               new Date(this.controllers[index].last_poll).getTime()) >
@@ -151,7 +155,7 @@ class dmxnet {
    * Builds and sends an ArtPollReply-Packet
    */
   ArtPollReply() {
-    log.debug('Send ArtPollReply');
+    this.logger.silly('Send ArtPollReply');
 
     this.ip4.forEach((ip) => {
       // BindIndex handles all the different "instance".
@@ -210,7 +214,7 @@ class dmxnet {
         client.send(udppacket, 0, udppacket.length, 6454, broadcastip,
           (err) => {
             if (err) throw err;
-            log.log('ArtPollReply frame sent');
+            this.logger.debug('ArtPollReply frame sent');
           });
       });
       // Send one package for every receiver
@@ -259,7 +263,7 @@ class dmxnet {
         client.send(udppacket, 0, udppacket.length, 6454, broadcastip,
           (err) => {
             if (err) throw err;
-            log.log('ArtPollReply frame sent');
+            this.logger.debug('ArtPollReply frame sent');
           });
       });
       if ((this.senders.length + this.receivers.length) < 1) {
@@ -297,13 +301,13 @@ class dmxnet {
             // BindIndex, Status2
             1, 0b00001110,
           ]));
-        log.debug('Packet content: ' + udppacket.toString('hex'));
+        this.logger.debug('Packet content: ' + udppacket.toString('hex'));
         // Send UDP
         var client = this.socket;
         client.send(udppacket, 0, udppacket.length, 6454, broadcastip,
           (err) => {
             if (err) throw err;
-            log.log('ArtPollReply frame sent');
+            this.logger.debug('ArtPollReply frame sent');
           });
       }
     });
@@ -337,7 +341,6 @@ class sender {
     this.subuni = options.subuni;
     this.ip = options.ip || '255.255.255.255';
     this.port = options.port || 6454;
-    this.verbose = this.parent.verbose;
     this.base_refresh_interval = options.base_refresh_interval || 1000;
 
     // Validate Input
@@ -353,10 +356,7 @@ class sender {
     if ((this.net < 0) || (this.subnet < 0) || (this.universe < 0)) {
       throw new Error('Subnet, Net or Universe must be 0 or bigger!');
     }
-    if (this.verbose > 0) {
-      log.log('new dmxnet sender started with params: ' +
-        JSON.stringify(options));
-    }
+    this.parent.logger.info('new dmxnet sender started with params: %o', options);
     // init dmx-value array
     this.values = [];
     // fill all 512 channels
@@ -413,13 +413,13 @@ class sender {
       // Increase Sequence Counter
       this.ArtDmxSeq++;
 
-      log.debug('Packet content: ' + udppacket.toString('hex'));
+      this.parent.logger.debug('Packet content: ' + udppacket.toString('hex'));
       // Send UDP
       var client = this.socket;
       client.send(udppacket, 0, udppacket.length, this.port, this.ip,
         (err) => {
           if (err) throw err;
-          log.log('ArtDMX frame sent to ' + this.ip + ':' + this.port);
+          this.parent.logger.silly('ArtDMX frame sent to ' + this.ip + ':' + this.port);
         });
     }
   }
@@ -550,7 +550,6 @@ class receiver extends EventEmitter {
     this.subnet = options.subnet || 0;
     this.universe = options.universe || 0;
     this.subuni = options.subuni;
-    this.verbose = this.parent.verbose;
 
     // Validate Input
     if (this.net > 127) {
@@ -565,10 +564,7 @@ class receiver extends EventEmitter {
     if ((this.net < 0) || (this.subnet < 0) || (this.universe < 0)) {
       throw new Error('Subnet, Net or Universe must be 0 or bigger!');
     }
-    if (this.verbose > 0) {
-      log.log('new dmxnet sender started with params: ' +
-        JSON.stringify(options));
-    }
+    this.parent.logger.info('new dmxnet sender started with params %o', options);
     // init dmx-value array
     this.values = [];
     // fill all 512 channels
@@ -596,47 +592,52 @@ class receiver extends EventEmitter {
 }
 
 // Parser & receiver
+/**
+ * @param {Buffer} msg - Message buffer to parse
+ * @param {dgram.RemoteInfo} rinfo - Remote info
+ * @param {dmxnet} parent - Instance of the dmxnet parent
+ */
 var dataParser = function (msg, rinfo, parent) {
-  log.debug(`got UDP from ${rinfo.address}:${rinfo.port}`);
+  parent.logger.silly(`got UDP from ${rinfo.address}:${rinfo.port}`);
   if (rinfo.size < 10) {
-    log.debug('Payload to short');
+    parent.logger.silly('Payload to short');
     return;
   }
   // Check first 8 bytes for the "Art-Net" - String
   if (String(jspack.Unpack('!8s', msg)) !== 'Art-Net\u0000') {
-    log.debug('Invalid header');
+    parent.logger.silly('Invalid header');
     return;
   }
   var opcode = parseInt(jspack.Unpack('B', msg, 8), 10);
   opcode += parseInt(jspack.Unpack('B', msg, 9), 10) * 256;
   if (!opcode || opcode === 0) {
-    log.debug('Invalid OpCode');
+    parent.logger.silly('Invalid OpCode');
     return;
   }
   switch (opcode) {
     case 0x5000:
-      log.debug('detected ArtDMX');
+      parent.logger.debug('detected ArtDMX');
       var universe = parseInt(jspack.Unpack('H', msg, 14), 10);
       var data = [];
       for (var ch = 1; ch <= msg.length - 18; ch++) {
         data.push(msg.readUInt8(ch + 17, true));
       }
-      log.debug('Received frame for SubUniNet 0x' + universe.toString(16));
+      parent.logger.debug('Received frame for SubUniNet 0x' + universe.toString(16));
       if (parent.receiversSubUni[universe]) {
         parent.receiversSubUni[universe].receive(data);
       }
       break;
     case 0x2000:
       if (rinfo.size < 14) {
-        log.debug('ArtPoll to small');
+        parent.logger.silly('ArtPoll to small');
         return;
       }
-      log.debug('detected ArtPoll');
+      parent.logger.debug('detected ArtPoll');
       // Parse Protocol version
       var proto = parseInt(jspack.Unpack('B', msg, 10), 10);
       proto += parseInt(jspack.Unpack('B', msg, 11), 10) * 256;
       if (!proto || proto < 14) {
-        log.debug('Invalid OpCode');
+        parent.logger.silly('Invalid OpCode');
         return;
       }
       // Parse TalkToMe
@@ -664,14 +665,14 @@ var dataParser = function (msg, rinfo, parent) {
         parent.controllers.push(ctrl);
       }
       parent.ArtPollReply();
-      log.debug('Controllers: ' + JSON.stringify(parent.controllers));
+      parent.logger.debug('Controllers: %o', parent.controllers);
       break;
     case 0x2100:
       // ToDo
-      log.debug('detected ArtPollReply');
+      parent.logger.debug('detected ArtPollReply');
       break;
     default:
-      log.debug('OpCode not implemented');
+      parent.logger.silly('OpCode not implemented');
   }
 
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,16 @@
       "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
       "dev": true
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@hibas123/logging": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@hibas123/logging/-/logging-2.1.0.tgz",
@@ -112,6 +122,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -181,11 +196,19 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -193,8 +216,30 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "comment-parser": {
       "version": "0.6.2",
@@ -207,6 +252,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -250,6 +300,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "entities": {
       "version": "1.1.2",
@@ -468,6 +523,16 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -502,6 +567,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -591,8 +661,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "6.5.2",
@@ -632,6 +701,11 @@
         }
       }
     },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -643,6 +717,16 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -743,6 +827,11 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -767,6 +856,18 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
     },
     "markdown-it": {
       "version": "8.4.2",
@@ -832,8 +933,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -871,6 +971,14 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -941,6 +1049,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -952,6 +1065,16 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
     },
     "regexpp": {
       "version": "2.0.1",
@@ -1026,6 +1149,11 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1059,6 +1187,14 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -1076,6 +1212,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1084,6 +1225,14 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -1156,6 +1305,11 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1176,6 +1330,11 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
       "version": "1.10.0",
@@ -1213,6 +1372,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -1220,6 +1384,60 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "homepage": "https://github.com/margau/dmxnet#readme",
   "dependencies": {
-    "@hibas123/nodelogging": "^2.0.6",
     "jspack": "0.0.4",
-    "netmask": "^1.0.6"
+    "netmask": "^1.0.6",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
Currently this package is extremely verbose by default, and writes to /tmp files and console by default. This PR replaces the previously included, but rarely popular logging lib `nodelogging` by the widely-used lib [`winston`](https://github.com/winstonjs/winston). Also it adjusts log levels, to have fine-grained control over the output (now varies from debug, over silly and verbose to info).

The previous `verbose` property in the option is replaced by [`log`](https://github.com/Patrick-Remy/dmxnet/blob/winston-logger/lib.d.ts#L117) to override and customize any logging behaviour. The simplest is to override log-level to e.g. `error`. 
```js
new dmxnet({
  log: { level: 'error' } 
})
```

or disable any outputs
```js
new dmxnet({
  transports: []
})
```

This resolves #24, #23 and #18.

Also the PR #19 can be closed after merging this.