### PR TITLE
Give `dmxnet` a default constructor.

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -19,7 +19,7 @@ class dmxnet {
    *
    * @param {object} options - Options for the whole instance
    */
-  constructor(options) {
+  constructor(options = {}) {
     // Parse all options and set defaults
     this.oem = options.oem || 0x2908; // OEM code hex
     this.port = options.listen || 6454; // Port listening for incoming data


### PR DESCRIPTION
According to the TypeScript definitions, you should be able to call ```new dmxnet()``` without providing an option object. Right now though, leaving this parameter empty throws ``TypeError: Cannot read property 'oem' of undefined``.
This pull request adds a default constructor to the `dmxnet` class so that it behaves according to the documentation.